### PR TITLE
Adds extra plugins to ktor client

### DIFF
--- a/data/src/main/kotlin/foo/bar/clean/data/api/rest/KtorBuilder.kt
+++ b/data/src/main/kotlin/foo/bar/clean/data/api/rest/KtorBuilder.kt
@@ -1,9 +1,15 @@
 package foo.bar.clean.data.api.rest
 
+import co.early.fore.kt.core.delegate.Fore
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.observer.ResponseObserver
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
@@ -16,6 +22,8 @@ import okhttp3.Interceptor
  * see @[co.early.fore.net.testhelpers.InterceptorStubbedService]
  *
  */
+private const val TIME_OUT = 10_000L
+
 object KtorBuilder {
 
     /**
@@ -39,6 +47,13 @@ object KtorBuilder {
                     Json {
                         isLenient = true
                         ignoreUnknownKeys = true
+                        /**
+                         * explicitNulls = false
+                         *
+                         * If 'explicitNulls = true' (the default), decoding will fail if Nullable properties (with no defaults) are not included in the JSON with kotlinx.serialization.MissingFieldException
+                         * When encoding with 'explicitNulls = false' Nullable properties (with null value) are not included in the JSON
+                         * See: https://github.com/Kotlin/kotlinx.serialization/blob/v1.5.1/docs/json.md#explicit-nulls
+                         */
                     }
                 )
             }
@@ -48,6 +63,34 @@ object KtorBuilder {
                     maxDelayMs = 3000,
                     randomizationMs = 2000
                 )
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = TIME_OUT
+                connectTimeoutMillis = TIME_OUT
+                socketTimeoutMillis = TIME_OUT
+            }
+            install(Logging) {
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        Fore.getLogger().i("Logger Ktor =>", message)
+                    }
+                }
+                level = LogLevel.INFO
+            }
+            /**
+             * Set common headers and/or url if required
+             *
+             * install(DefaultRequest) {
+             * header(HttpHeaders.ContentType, ContentType.Application.Json)
+             * }
+             */
+            install(ResponseObserver) {
+                onResponse { response ->
+                    Fore.getLogger().i(
+                        "HTTP status code:",
+                        "${response.status.value} ${response.status.description}"
+                    )
+                }
             }
         }
     }

--- a/dependencies-data.gradle
+++ b/dependencies-data.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation(libs.ktor.negotiation)
     implementation(libs.ktor.okhttp)
     implementation(libs.ktor.serialization)
+    implementation(libs.ktor.logging)
     implementation(libs.fore.network)
     // gql
     implementation(libs.apollo)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ fore-compose = { module = "co.early.fore:fore-kt-android-compose", version.ref =
 ktor-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktorVersion" }
 ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktorVersion" }
 ktor-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktorVersion" }
+ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktorVersion" }
 sqldelightGradlePlugin = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqlDelightVersion" }
 sqldelight-core = { module = "app.cash.sqldelight:runtime", version.ref = "sqlDelightVersion" }
 sqldelight-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelightVersion" }


### PR DESCRIPTION
Adds HttpTimeout, Logging and ResponseObserver Plugins

The DefaultRequest plugin has been added, but commented out as it might be useful in some use cases (it could however lead to duplicate headers being sent depending on the underlying OkHttp client sends).

The HttpTimeout plugin might also be competing with Okhttp in which case it could be removed/ disabled.

The logging plugin is probably the most useful as when the log level is set to LogLevel.ALL all request and responses are logged including whole JSON for debugging etc. The ResponseObserver can succinctly report responses
 